### PR TITLE
feat(cookies): add same_site parameter to unset_cookie for consistency

### DIFF
--- a/docs/_newsfragments/2453.newandimproved.rst
+++ b/docs/_newsfragments/2453.newandimproved.rst
@@ -1,0 +1,4 @@
+The :meth:`~falcon.Response.unset_cookie` method now accepts a ``same_site``
+parameter (with underscore) for consistency with :meth:`~falcon.Response.set_cookie`.
+The previous ``samesite`` parameter (without underscore) is now deprecated and will
+emit a deprecation warning when used.

--- a/docs/api/cookies.rst
+++ b/docs/api/cookies.rst
@@ -160,7 +160,7 @@ default, although this may change in a future release.
 
 When unsetting a cookie, :meth:`~falcon.Response.unset_cookie`,
 the default `SameSite` setting of the unset cookie is ``'Lax'``, but can be changed
-by setting the 'samesite' kwarg.
+by setting the 'same_site' kwarg.
 
 The Partitioned Attribute
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -35,6 +35,7 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
+import warnings
 
 from falcon._typing import _UNSET
 from falcon._typing import RangeSetHeader
@@ -56,6 +57,7 @@ from falcon.util import http_cookies
 from falcon.util import http_status_to_code
 from falcon.util import structures
 from falcon.util.deprecation import AttributeRemovedError
+from falcon.util.deprecation import DeprecatedWarning
 from falcon.util.uri import encode_check_escaped as uri_encode
 from falcon.util.uri import encode_value_check_escaped as uri_encode_value
 
@@ -563,9 +565,10 @@ class Response:
     def unset_cookie(
         self,
         name: str,
-        samesite: str = 'Lax',
+        samesite: Optional[str] = None,
         domain: Optional[str] = None,
         path: Optional[str] = None,
+        same_site: str = 'Lax',
     ) -> None:
         """Unset a cookie in the response.
 
@@ -588,10 +591,10 @@ class Response:
             name (str): Cookie name
 
         Keyword Args:
-            samesite (str): Allows to override the default 'Lax' same_site
-                    setting for the unset cookie.
+            samesite (str): Deprecated. Use `same_site` instead.
 
-                    .. versionadded:: 4.0
+                    .. deprecated:: 4.1
+                       Please use the ``same_site`` parameter instead.
 
             domain (str): Restricts the cookie to a specific domain and
                     any subdomains of that domain. By default, the user
@@ -619,6 +622,11 @@ class Response:
 
                 (See also: RFC 6265, Section 4.1.2.4)
 
+            same_site (str): Allows to override the default 'Lax' same_site
+                    setting for the unset cookie.
+
+                    .. versionadded:: 4.1
+
         .. _Same-Site warnings:
             https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#Fixing_common_warnings
         """  # noqa: E501
@@ -634,9 +642,21 @@ class Response:
         # thus removing it from future request objects.
         self._cookies[name]['expires'] = -1
 
+        # Handle deprecated samesite parameter
+        if samesite is not None:
+            warnings.warn(
+                'The "samesite" parameter is deprecated. Please use "same_site" instead.',
+                DeprecatedWarning,
+                stacklevel=2
+            )
+            # Use the deprecated parameter value if same_site was not explicitly set
+            same_site_value = samesite
+        else:
+            same_site_value = same_site
+
         # NOTE(CaselIT): Set SameSite to Lax to avoid setting invalid cookies.
         # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#Fixing_common_warnings  # noqa: E501
-        self._cookies[name]['samesite'] = samesite
+        self._cookies[name]['samesite'] = same_site_value
 
         if domain:
             self._cookies[name]['domain'] = domain

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -3,12 +3,14 @@ from datetime import timedelta
 from datetime import timezone
 from http import cookies as http_cookies
 import re
+import warnings
 
 import pytest
 
 import falcon
 import falcon.testing as testing
 from falcon.util import http_date_to_dt
+from falcon.util.deprecation import DeprecatedWarning
 from falcon.util.misc import _utcnow
 
 UNICODE_TEST_STRING = 'Unicode_\xc3\xa6\xc3\xb8'
@@ -76,20 +78,20 @@ class CookieUnset:
         resp.unset_cookie('baz', domain='www.example.com')
         resp.unset_cookie('foobar', path='/foo', domain='www.example.com')
         resp.unset_cookie(
-            'barfoo', samesite='none', path='/foo', domain='www.example.com'
+            'barfoo', same_site='none', path='/foo', domain='www.example.com'
         )
 
 
 class CookieUnsetSameSite:
     def on_get(self, req, resp):
         # change lax to strict
-        resp.unset_cookie('foo', samesite='Strict')
+        resp.unset_cookie('foo', same_site='Strict')
         # change strict to lax
         resp.unset_cookie('bar')
         # change none to ''
-        resp.unset_cookie('baz', samesite='')
+        resp.unset_cookie('baz', same_site='')
         # change '' to none
-        resp.unset_cookie('barz', samesite='None')
+        resp.unset_cookie('barz', same_site='None')
 
 
 @pytest.fixture
@@ -190,11 +192,11 @@ def test_unset_cookies(client):
     result = client.simulate_get('/unset-cookie')
     assert len(result.cookies) == 5
 
-    def test(cookie, path, domain, samesite='Lax'):
+    def test(cookie, path, domain, same_site='Lax'):
         assert cookie.value == ''  # An unset cookie has an empty value
         assert cookie.domain == domain
         assert cookie.path == path
-        assert cookie.same_site == samesite
+        assert cookie.same_site == same_site
         assert cookie.expires < _utcnow()
 
     test(result.cookies['foo'], path=None, domain=None)
@@ -202,7 +204,7 @@ def test_unset_cookies(client):
     test(result.cookies['baz'], path=None, domain='www.example.com')
     test(result.cookies['foobar'], path='/foo', domain='www.example.com')
     test(
-        result.cookies['barfoo'], path='/foo', domain='www.example.com', samesite='none'
+        result.cookies['barfoo'], path='/foo', domain='www.example.com', same_site='none'
     )
 
 
@@ -230,20 +232,20 @@ def test_unset_cookies_samesite(client):
     result_unset = client.simulate_get('/unset-cookie-same-site')
     assert len(result_unset.cookies) == 4
 
-    def test_unset(cookie, samesite='Lax'):
+    def test_unset(cookie, same_site='Lax'):
         assert cookie.value == ''  # An unset cookie has an empty value
-        assert cookie.same_site == samesite
+        assert cookie.same_site == same_site
         assert cookie.expires < _utcnow()
 
-    test_unset(result_unset.cookies['foo'], samesite='Strict')
-    # default: bar is unset with no samesite param, so should go to Lax
-    test_unset(result_unset.cookies['bar'], samesite='Lax')
+    test_unset(result_unset.cookies['foo'], same_site='Strict')
+    # default: bar is unset with no same_site param, so should go to Lax
+    test_unset(result_unset.cookies['bar'], same_site='Lax')
     test_unset(result_unset.cookies['bar'])  # default in test_unset
 
     test_unset(
-        result_unset.cookies['baz'], samesite=None
-    )  # baz gets unset to samesite = ''
-    test_unset(result_unset.cookies['barz'], samesite='None')
+        result_unset.cookies['baz'], same_site=None
+    )  # baz gets unset to same_site = ''
+    test_unset(result_unset.cookies['barz'], same_site='None')
     # test for false
     assert result_unset.cookies['baz'].same_site != 'Strict'
     assert result_unset.cookies['foo'].same_site != 'Lax'
@@ -530,3 +532,24 @@ def test_partitioned_value(client):
 
     cookie = result.cookies['baz']
     assert not cookie.partitioned
+
+
+def test_unset_cookie_deprecation_warning():
+    resp = falcon.Response()
+    
+    # Test that using the deprecated 'samesite' parameter raises a warning
+    with pytest.warns(DeprecatedWarning, match='The "samesite" parameter is deprecated'):
+        resp.unset_cookie('test', samesite='Strict')
+    
+    # Verify the cookie was still set correctly with the deprecated parameter
+    morsel = resp._cookies['test']
+    assert morsel['samesite'] == 'Strict'
+    
+    # Test that using the new 'same_site' parameter doesn't raise a warning
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        resp.unset_cookie('test2', same_site='Lax')
+    
+    # Verify the cookie was set correctly with the new parameter
+    morsel2 = resp._cookies['test2']
+    assert morsel2['samesite'] == 'Lax'


### PR DESCRIPTION
## Summary

- Add `same_site` parameter to `Response.unset_cookie()` method for consistency with `Response.set_cookie()` method
- Deprecate the previous `samesite` parameter with a deprecation warning
- Update tests and documentation to use the new parameter name

## Details

The `Response.set_cookie()` method uses `same_site` parameter (with underscore) while `Response.unset_cookie()` was using `samesite` parameter (without underscore). This inconsistency made the API confusing to use.

This change:
- Adds `same_site` parameter to `unset_cookie()` for consistency
- Maintains backward compatibility by keeping the old `samesite` parameter
- Emits a `DeprecatedWarning` when the old parameter is used
- Updates all tests to use the new parameter name
- Updates documentation to reflect the change

## Test Plan

- [x] All existing cookie tests pass (51 tests)
- [x] New deprecation warning test passes
- [x] ASGI cookie tests pass
- [x] Response tests pass
- [x] Changelog fragment renders correctly with towncrier

Closes #2453